### PR TITLE
Add distance-based precision enum

### DIFF
--- a/Demo/Demo/ContentView.swift
+++ b/Demo/Demo/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
     var body: some View {
         Text(result)
         Button("aaa") {
-            result = GeoHash.create(lat: 135, lon: 35.001, digitCount: 10)
+            result = GeoHash.create(lat: 135, lon: 35.001, precision: .m0_6)
         }
     }
 

--- a/Sources/GeoHashKit/GeoHashKit.swift
+++ b/Sources/GeoHashKit/GeoHashKit.swift
@@ -1,6 +1,41 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
 
+public enum Precision: Int {
+    /// roughly 2500km
+    case km2500 = 1
+    /// roughly 630km
+    case km630
+    /// roughly 78km
+    case km78
+    /// roughly 20km
+    case km20
+    /// roughly 2.4km
+    case km2_4
+    /// roughly 610m
+    case m610
+    /// roughly 76m
+    case m76
+    /// roughly 19m
+    case m19
+    /// roughly 2.4m
+    case m2_4
+    /// roughly 0.6m
+    case m0_6
+    /// roughly 7.4cm
+    case cm7_4
+    /// roughly 1.9cm
+    case cm1_9
+    /// roughly 0.24cm
+    case mm0_24
+    /// roughly 0.06cm
+    case mm0_06
+    /// roughly 0.0074cm
+    case mm0_0074
+    /// roughly 0.0019cm
+    case mm0_0019
+}
+
 public enum GeoHash {
     public static func create(lat: Double, lon: Double, digitCount: Int) -> String {
         let base32 = Array("0123456789bcdefghjkmnpqrstuvwxyz")
@@ -39,5 +74,9 @@ public enum GeoHash {
             }
         }
         return geohash
+    }
+
+    public static func create(lat: Double, lon: Double, precision: Precision) -> String {
+        return create(lat: lat, lon: lon, digitCount: precision.rawValue)
     }
 }


### PR DESCRIPTION
## Summary
- update `Precision` enum to use approximate kilometer/meter names
- update demo to call `GeoHash.create` with `.m0_6`

## Testing
- `swift build`
- `swift test` *(fails: no tests found)*